### PR TITLE
fix stuck-crouch bug

### DIFF
--- a/Scripts/playerMovementScripts/Crouched.gd
+++ b/Scripts/playerMovementScripts/Crouched.gd
@@ -6,7 +6,10 @@ func enter(msg := {}) -> void:
 	print("crouched")
 	stats.crouched = true
 	stats.speed = stats.ply_crouchspeed 
-	try_uncrouch = false
+	if msg.get("try_uncrouch") == true:
+		try_uncrouch = true;
+	else:
+		try_uncrouch = false
 	
 	
 func physics_update(delta: float) -> void:

--- a/Scripts/playerMovementScripts/Crouching.gd
+++ b/Scripts/playerMovementScripts/Crouching.gd
@@ -28,4 +28,4 @@ func physics_update(delta: float) -> void:
 		player.move_and_collide(Vector3(0,0.1, 0))
 	
 	if(player.myShape.scale.y <=0.5 ):
-		state_machine.transition_to("Crouched")
+		state_machine.transition_to("Crouched", {try_uncrouch=try_uncrouch})


### PR DESCRIPTION
it's possible in certain circumstances for the player to get stuck in the crouched state; this fix attempts to resolve this bug.

### Steps to reproduce

1. while standing, move the player into a low roof where their head touches a ceiling, such as the underside of the tilted Block4 in the demo map.
2. quickly press and release the crouch button (Ctrl) within 5 physics ticks, or about 1/12 of a second.
3. move the player out from underneath the low roof.

Expectation: the player uncrouches.
Actual result: the player stays crouched, as if there is a roof over their head.

### Problem

this bug is triggered when the player attempts to uncrouch while in the transitory `Crouching` state (rather than the fully-crouched `Crouched` state).

the boolean flag `try_uncrouch` is set when the player releases the crouch button in either `Crouching` or `Crouched`, and informs the game to attempt to uncrouch them every physics tick. however, if the player tries to uncrouch while in the `Crouching` state (releasing the key within the first five ticks of pressing it), the `try_uncrouch` flag is lost when the transition to `Crouched` is made

### Fix

the most dead-simple fix is to simply pass the flag as part of the `msg` in `StateMachine::transition_to`, which is what this commit does.